### PR TITLE
[DRAFT] Move an object's dependencies to a destination folder.

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1509,37 +1509,162 @@ bool FileSystemDock::_check_existing() {
 	}
 	return true;
 }
+void FileSystemDock::_move_operation_with_deps_confirm(const String &p_to_path) {
+	_move_operation_confirm(p_to_path, false, true);
+}
 
-void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_overwrite) {
+void FileSystemDock::_find_to_dependency_delete(TreeItem *p_item, Array &paths) {
+	while (p_item) {
+		bool is_check_cell = p_item->get_cell_mode(DEPS_CHECKBOX_COLUMN) == TreeItem::CELL_MODE_CHECK;
+		bool is_checked = p_item->is_checked(DEPS_CHECKBOX_COLUMN);
+		if (is_check_cell && is_checked) {
+			String path = p_item->get_text(DEPS_PATH_COLUMN);
+			paths.push_back(path);
+		}
+
+		if (p_item->get_children()) {
+			_find_to_dependency_delete(p_item->get_children(), paths);
+		}
+
+		p_item = p_item->get_next();
+	}
+}
+
+void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_overwrite, bool p_move_dependencies) {
+	bool can_move = false;
 	if (!p_overwrite) {
 		to_move_path = p_to_path;
-		bool can_move = _check_existing();
+		can_move = _check_existing();
 		if (!can_move) {
 			// Ask to do something.
 			overwrite_dialog->popup_centered();
 			return;
 		}
 	}
-
-	// Check groups.
-	for (int i = 0; i < to_move.size(); i++) {
-		if (to_move[i].is_file && EditorFileSystem::get_singleton()->is_group_file(to_move[i].path)) {
-			EditorFileSystem::get_singleton()->move_group_file(to_move[i].path, p_to_path.plus_file(to_move[i].path.get_file()));
-		}
-	}
-
-	Map<String, String> file_renames;
-	Map<String, String> folder_renames;
-	bool is_moved = false;
-	for (int i = 0; i < to_move.size(); i++) {
+	for (int i = 0; i < to_move.size(); ++i) {
 		String old_path = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
 		String new_path = p_to_path.plus_file(old_path.get_file());
 		if (old_path != new_path) {
-			_try_move_item(to_move[i], new_path, file_renames, folder_renames);
-			is_moved = true;
+			to_move_path = p_to_path.plus_file(old_path.get_file());
+			can_move = can_move && _check_existing();
+			if (!p_move_dependencies) {
+				continue;
+			}
+			List<String> deps;
+			ResourceLoader::get_dependencies(new_path, &deps, false);
+			for (int i = 0; i < deps.size(); ++i) {
+				to_move_path = p_to_path.plus_file(old_path.get_file());
+				can_move = can_move && _check_existing();
+			}
 		}
 	}
+	if (!can_move) {
+		ignore_overwrite_with_deps_dialog->grab_focus();
+		return;
+	} else {
+		overwrite_dialog->grab_focus();
+		if (p_move_dependencies) {
+			new_deps_tree->clear();
+			new_deps_tree->set_v_size_flags(SIZE_EXPAND_FILL);
+			new_deps_tree->set_column_titles_visible(true);
+			new_deps_tree->set_columns(3);
+			new_deps_tree->set_column_title(DEPS_PATH_COLUMN, TTR("Path"));
+			new_deps_tree->set_column_expand(DEPS_PATH_COLUMN, true);
+			new_deps_tree->set_column_min_width(DEPS_PATH_COLUMN, 1040 * EDSCALE);
+			new_deps_tree->set_column_title(DEPS_RESOURCE_COLUMN, TTR("Resource"));
+			new_deps_tree->set_column_expand(DEPS_RESOURCE_COLUMN, true);
+			new_deps_tree->set_column_min_width(DEPS_RESOURCE_COLUMN, 340 * EDSCALE);
+			new_deps_tree->set_column_title(DEPS_CHECKBOX_COLUMN, TTR("Move"));
+			new_deps_tree->set_column_min_width(DEPS_CHECKBOX_COLUMN, 40 * EDSCALE);
+			new_deps_tree->set_column_expand(DEPS_CHECKBOX_COLUMN, true);
+			TreeItem *root = new_deps_tree->create_item();
+			new_deps_tree->set_hide_root(true);
+			Set<String> file_dependencies;
+			for (int i = 0; i < to_move.size(); ++i) {
+				String old_path = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
+				_scan_file_dependencies(old_path, file_dependencies);
+				file_dependencies.insert(old_path);
+			}
+			for (Set<String>::Element *E = file_dependencies.front(); E; E = E->next()) {
+				TreeItem *item = new_deps_tree->create_item(root);
 
+				// Check groups.
+				for (int i = 0; i < to_move.size(); i++) {
+					if (to_move[i].is_file && EditorFileSystem::get_singleton()->is_group_file(to_move[i].path)) {
+						EditorFileSystem::get_singleton()->move_group_file(to_move[i].path, p_to_path.plus_file(to_move[i].path.get_file()));
+					}
+				}
+
+				String n = E->get();
+				String path;
+				String type;
+
+				if (n.find("::") != String::npos) {
+					path = n.get_slice("::", 0);
+					type = n.get_slice("::", 1);
+				} else {
+					path = n;
+					type = "Resource";
+				}
+				String name = path.get_file();
+				Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(type);
+				item->set_text(DEPS_RESOURCE_COLUMN, name);
+				item->set_icon(DEPS_RESOURCE_COLUMN, icon);
+				item->set_metadata(DEPS_RESOURCE_COLUMN, type);
+				item->set_selectable(DEPS_RESOURCE_COLUMN, false);
+				item->set_text(DEPS_PATH_COLUMN, path);
+				item->set_selectable(DEPS_PATH_COLUMN, false);
+				item->set_cell_mode(DEPS_CHECKBOX_COLUMN, TreeItem::TreeCellMode::CELL_MODE_CHECK);
+				item->set_editable(DEPS_CHECKBOX_COLUMN, true);
+				item->set_checked(DEPS_CHECKBOX_COLUMN, true);
+			}
+			new_deps_dialog->popup_centered_ratio();
+			new_deps_dialog->disconnect_compat("confirmed", this, "_move_dependencies");
+			new_deps_dialog->connect_compat("confirmed", this, "_move_dependencies", varray(p_to_path, p_move_dependencies));
+			return;
+		}
+		_move_dependencies(p_to_path, p_move_dependencies);
+	}
+}
+
+void FileSystemDock::_scan_file_dependencies(String p_path, Set<String> &p_file_dependencies) {
+	List<String> deps;
+	ResourceLoader::get_dependencies(p_path, &deps, false);
+	for (List<String>::Element *E = deps.front(); E; E = E->next()) {
+		if (p_file_dependencies.has(E->get())) {
+			continue;
+		}
+		p_file_dependencies.insert(E->get());
+		_scan_file_dependencies(E->get(), p_file_dependencies);
+	}
+}
+
+void FileSystemDock::_move_dependencies(String p_to_path, bool p_move_dependencies) {
+	Map<String, String> file_renames;
+	Map<String, String> folder_renames;
+	bool is_moved = false;
+	if (!p_move_dependencies) {
+		for (int i = 0; i < to_move.size(); ++i) {
+			String old_path = to_move[i].path.ends_with("/") ? to_move[i].path.substr(0, to_move[i].path.length() - 1) : to_move[i].path;
+			String new_path = p_to_path.plus_file(old_path.get_file());
+			if (old_path != new_path) {
+				_try_move_item(to_move[i], new_path, file_renames, folder_renames);
+				is_moved = true;
+			}
+		}
+	} else {
+		Array move_paths;
+		_find_to_dependency_delete(new_deps_tree->get_root(), move_paths);
+		for (int32_t i = 0; i < move_paths.size(); ++i) {
+			String old_path = move_paths[i];
+			String new_path = p_to_path.plus_file(String(move_paths[i]).get_file());
+			print_verbose("Moving dependencies for: " + old_path);
+			if (old_path != new_path) {
+				is_moved = true;
+				_try_move_item(FileOrFolder(old_path, true), new_path, file_renames, folder_renames);
+			}
+		}
+	}
 	if (is_moved) {
 		int current_tab = editor->get_current_tab();
 		_save_scenes_after_move(file_renames); // Save scenes before updating.
@@ -1750,17 +1875,16 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 		} break;
 
 		case FILE_MOVE: {
-			// Move the files to a given location.
+			// Move the files to a given location
 			to_move.clear();
-			Vector<String> collapsed_paths = _remove_self_included_paths(p_selected);
-			for (int i = collapsed_paths.size() - 1; i >= 0; i--) {
-				String fpath = collapsed_paths[i];
+			for (int i = 0; i < p_selected.size(); ++i) {
+				String fpath = p_selected[i];
 				if (fpath != "res://") {
 					to_move.push_back(FileOrFolder(fpath, !fpath.ends_with("/")));
 				}
 			}
 			if (to_move.size() > 0) {
-				move_dialog->popup_centered_ratio();
+				move_with_deps_dialog->popup_centered_ratio();
 			}
 		} break;
 
@@ -2641,6 +2765,20 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_file_list_thumbnail_done"), &FileSystemDock::_file_list_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_tree_thumbnail_done"), &FileSystemDock::_tree_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_select_file"), &FileSystemDock::_select_file);
+	ClassDB::bind_method(D_METHOD("_navigate_to_path"), &FileSystemDock::_navigate_to_path, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("_toggle_file_display"), &FileSystemDock::_toggle_file_display);
+	ClassDB::bind_method(D_METHOD("_fw_history"), &FileSystemDock::_fw_history);
+	ClassDB::bind_method(D_METHOD("_bw_history"), &FileSystemDock::_bw_history);
+	ClassDB::bind_method(D_METHOD("_fs_changed"), &FileSystemDock::_fs_changed);
+	ClassDB::bind_method(D_METHOD("_tree_multi_selected"), &FileSystemDock::_tree_multi_selected);
+	ClassDB::bind_method(D_METHOD("_make_dir_confirm"), &FileSystemDock::_make_dir_confirm);
+	ClassDB::bind_method(D_METHOD("_resource_created"), &FileSystemDock::_resource_created);
+	ClassDB::bind_method(D_METHOD("_move_operation_confirm", "to_path", "overwrite", "with_dependencies"), &FileSystemDock::_move_operation_confirm, DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("_move_operation_with_deps_confirm", "to_path"), &FileSystemDock::_move_operation_with_deps_confirm);
+
+	ClassDB::bind_method(D_METHOD("_move_with_overwrite"), &FileSystemDock::_move_with_overwrite);
+	ClassDB::bind_method(D_METHOD("_rename_operation_confirm"), &FileSystemDock::_rename_operation_confirm);
+	ClassDB::bind_method(D_METHOD("_duplicate_operation_confirm"), &FileSystemDock::_duplicate_operation_confirm);
 
 	ClassDB::bind_method(D_METHOD("get_drag_data_fw", "position", "from"), &FileSystemDock::get_drag_data_fw);
 	ClassDB::bind_method(D_METHOD("can_drop_data_fw", "position", "data", "from"), &FileSystemDock::can_drop_data_fw);
@@ -2648,6 +2786,8 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("navigate_to_path", "path"), &FileSystemDock::navigate_to_path);
 
 	ClassDB::bind_method(D_METHOD("_update_import_dock"), &FileSystemDock::_update_import_dock);
+
+	ClassDB::bind_method(D_METHOD("_move_dependencies"), &FileSystemDock::_move_dependencies);
 
 	ADD_SIGNAL(MethodInfo("inherit", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("instance", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
@@ -2811,7 +2951,12 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	move_dialog = memnew(EditorDirDialog);
 	move_dialog->get_ok()->set_text(TTR("Move"));
 	add_child(move_dialog);
-	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_confirm), make_binds(false));
+	move_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_confirm), make_binds(false, false));
+
+	move_with_deps_dialog = memnew(EditorDirDialog);
+	move_with_deps_dialog->get_ok()->set_text(TTR("Move with Dependencies"));
+	add_child(move_with_deps_dialog);
+	move_with_deps_dialog->connect("dir_selected", callable_mp(this, &FileSystemDock::_move_operation_with_deps_confirm));
 
 	rename_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *rename_dialog_vb = memnew(VBoxContainer);
@@ -2829,6 +2974,10 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	overwrite_dialog->get_ok()->set_text(TTR("Overwrite"));
 	add_child(overwrite_dialog);
 	overwrite_dialog->connect("confirmed", callable_mp(this, &FileSystemDock::_move_with_overwrite));
+
+	ignore_overwrite_with_deps_dialog = memnew(ConfirmationDialog);
+	ignore_overwrite_with_deps_dialog->set_text(TTR("There is already file or folder with the same name in this location."));
+	add_child(ignore_overwrite_with_deps_dialog);
 
 	duplicate_dialog = memnew(ConfirmationDialog);
 	VBoxContainer *duplicate_dialog_vb = memnew(VBoxContainer);
@@ -2871,6 +3020,12 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
 	new_resource_dialog->connect("create", callable_mp(this, &FileSystemDock::_resource_created));
+
+	new_deps_dialog = memnew(ConfirmationDialog);
+	add_child(new_deps_dialog);
+	new_deps_tree = memnew(Tree);
+	new_deps_dialog->add_child(new_deps_tree);
+	new_deps_dialog->connect("confirmed", callable_mp(this,  &FileSystemDock::_move_dependencies), make_binds("", false, Array()));
 
 	searched_string = String();
 	uncollapsed_paths_before_search = Vector<String>();

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -104,6 +104,11 @@ private:
 		FOLDER_EXPAND_ALL,
 		FOLDER_COLLAPSE_ALL,
 	};
+	enum DependencyColumn {
+		DEPS_PATH_COLUMN,
+		DEPS_RESOURCE_COLUMN,
+		DEPS_CHECKBOX_COLUMN
+	};
 
 	FileSortOption file_sort = FILE_SORT_NAME;
 
@@ -147,6 +152,10 @@ private:
 	DependencyRemoveDialog *remove_dialog;
 
 	EditorDirDialog *move_dialog;
+	EditorDirDialog *move_with_deps_dialog;
+	ConfirmationDialog *new_deps_dialog;
+
+	Tree *new_deps_tree;
 	ConfirmationDialog *rename_dialog;
 	LineEdit *rename_dialog_text;
 	ConfirmationDialog *duplicate_dialog;
@@ -157,6 +166,8 @@ private:
 	LineEdit *make_scene_dialog_text;
 	ConfirmationDialog *overwrite_dialog;
 	ScriptCreateDialog *make_script_dialog;
+	ConfirmationDialog *ignore_overwrite_with_deps_dialog;
+	ScriptCreateDialog *make_script_dialog_text;
 	CreateDialog *new_resource_dialog;
 
 	bool always_show_folders;
@@ -237,8 +248,10 @@ private:
 	void _duplicate_operation_confirm();
 	void _move_with_overwrite();
 	bool _check_existing();
-	void _move_operation_confirm(const String &p_to_path, bool p_overwrite = false);
 
+	void _move_operation_with_deps_confirm(const String &p_to_path);
+	void _move_operation_confirm(const String &p_to_path, bool overwrite = false, bool with_dependencies = false);
+	void _scan_dependencies_to_delete(String old_path, Set<String> &dependencies_to_delete);
 	void _tree_rmb_option(int p_option);
 	void _file_list_rmb_option(int p_option);
 	void _file_option(int p_option, const Vector<String> &p_selected);
@@ -250,6 +263,9 @@ private:
 
 	void _set_scanning_mode();
 	void _rescan();
+
+	void _find_to_dependency_delete(TreeItem *p_item, Array &paths);
+	void _move_dependencies(String p_to_path, bool p_move_dependencies);
 
 	void _toggle_split_mode(bool p_active);
 
@@ -299,6 +315,7 @@ private:
 	void _update_display_mode(bool p_force = false);
 
 	Vector<String> _tree_get_selected(bool remove_self_inclusion = true);
+	void _scan_file_dependencies(String p_path, Set<String> &p_file_dependencies);
 
 	bool _is_file_type_disabled_by_feature_profile(const StringName &p_class);
 


### PR DESCRIPTION
<img width="2628" alt="Screen Shot 2020-10-29 at 9 09 11 AM" src="https://user-images.githubusercontent.com/32321/97600574-6eea4d00-19c6-11eb-8b30-e00132dc4915.png">

* Ignore case when the file is not kept.
* Remove duplicates.
* Can now click on checkbox.
* Scan all dependencies.